### PR TITLE
Fix link to current app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 >"Naming colors has never been this easy!"
 > \- **_Abraham Lincoln_**
 
-A [web app](colornamer.netlify.com) that provides a name for a color. EZPZ.
+A [web app](https://colornamer.robertcooper.me/) that provides a name for a color. EZPZ.
 
 ![Example usage GIF](./example.gif)
 


### PR DESCRIPTION
I came here via https://colornamer.robertcooper.me/. But the links from here don't go there. The link in the readme is broken since it is relative. But also the netlify link is down.

Btw, the same link should be adjusted in the repositories link:

![afbeelding](https://github.com/user-attachments/assets/85686e1c-2550-46b5-89d4-e02d08fbde4d)

Thanks for this fun tool! :sparkles: 